### PR TITLE
Fix heading in example prompts

### DIFF
--- a/example_prompts.md
+++ b/example_prompts.md
@@ -1,7 +1,7 @@
 # Example Multi-file Prompts
 Here are three prompts designed to encourage the AI Planner/Developer to create a multi-file Python application, keeping in mind the MVP's focus on standard libraries. These prompts are for the *user* to input into the Streamlit app at the "INPUT_REQUIREMENTS" stage.
 
-## Prompt 1: Simple Web Scraper and Data Saver**
+## Prompt 1: Simple Web Scraper and Data Saver
 
 ```text
 "


### PR DESCRIPTION
## Summary
- remove extra `**` on the heading for prompt 1

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68412c791a2883299e55ab110a6c2c74