### PR TITLE
Add wiki pages

### DIFF
--- a/docs/wiki/Design-Overview.md
+++ b/docs/wiki/Design-Overview.md
@@ -1,0 +1,5 @@
+# Design Overview
+
+This project follows a series of PocketFlow segments coordinated through a Streamlit interface. The main requirements include using OpenAI LLMs to generate, test, validate, and refine a Python function with human feedback. Persistent state is stored in SQLite and the entire application is containerized via Docker.
+
+See [`docs/design.md`](../design.md) for the full design document.

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,11 @@
+# Getting Started
+
+Follow these steps to run the project locally:
+
+1. Install requirements from `requirements.txt` or use Docker Compose.
+2. Set your OpenAI API key in the environment (`OPENAI_API_KEY`).
+3. Run `streamlit run app.py` (or `docker compose up --build`).
+4. Open `http://localhost:8501` in your browser and follow the prompts.
+5. Unit tests can be executed with `python -m unittest`.
+
+Refer to the [Design Document](Design-Overview.md) for more background on how the system works.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,22 @@
+# Autonomous Software Factory
+
+Welcome to the project wiki! This repository contains a minimal prototype that demonstrates an "Autonomous Software Factory" using Streamlit, PocketFlow, and OpenAI LLMs.
+
+## Key Features
+
+- Interactive Streamlit GUI for user input and feedback
+- PocketFlow orchestration for planning, coding, testing, critique, and refinement
+- Multiple LLM-powered agents (Architect/Planner, Developer, Test Case Designer, QA, Validation, Critique, Security/Compliance)
+- Human-in-the-loop steps for clarification and final approval
+- Iterative refinement with configurable limits
+- File-based RAG context for guidelines
+- SQLite persistence for tasks and results
+- Dockerized deployment for ease of use
+
+## Wiki Pages
+
+- [Getting Started](Getting-Started.md)
+- [Design Overview](Design-Overview.md)
+- [Nodes and Flows](Nodes-and-Flows.md)
+
+See the [README](../README.md) for a more detailed overview.

--- a/docs/wiki/Nodes-and-Flows.md
+++ b/docs/wiki/Nodes-and-Flows.md
@@ -1,0 +1,14 @@
+# Nodes and Flows
+
+Nodes define discrete AI-driven steps in PocketFlow. Important nodes include:
+
+- **ArchitectPlannerNode** – clarifies the request and outputs a plan
+- **DeveloperNode** – generates or refines code
+- **TestCaseDesignerNode** – proposes tests for the planned function
+- **QANode** – runs tests using the provided `code_tester_tool`
+- **ValidationNode** – checks style rules and guidelines
+- **SecurityComplianceNode** – reviews basic security/compliance concerns
+- **CritiqueNode** – gives feedback when tests or validation fail or when the user rejects the code
+- **PackageNode** – assembles the final artifacts
+
+Flows wire these nodes together to create stages such as elicitation, code generation, QA/validation, critique, and packaging.


### PR DESCRIPTION
## Summary
- add project wiki directory with Home, Getting Started, Design Overview, and Nodes/Flows pages

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_68412ab690c08329a35a7f6be41186ea