### PR TITLE
Fix example prompt typo

### DIFF
--- a/example_prompts.md
+++ b/example_prompts.md
@@ -14,7 +14,6 @@ The scraper should handle basic requests errors gracefully.
 
 "
 ```
-update test case 1 to actual. find another url for 3, the connection error isn't happening
 **Why this should lead to multi-file:**
 
 * Explicitly mentions two files: `scraper_utils.py` and `app.py`.


### PR DESCRIPTION
## Summary
- remove stray line from prompt text in `example_prompts.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68412f9dad6483298cb1f341c7081b01